### PR TITLE
Bump compile sdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,11 +25,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdk 34
     namespace "com.sayegh.move_to_background"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 23
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+    namespace "com.sayegh.move_to_background"
 
     defaultConfig {
         minSdkVersion 16

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.sayegh.move_to_background">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Bump compile sdk to 34 for latest Play Store compatibility, and also use namespace instead of package.